### PR TITLE
CSS rule to disable text selection highlighting on editor window

### DIFF
--- a/static/css/cats.css
+++ b/static/css/cats.css
@@ -76,6 +76,10 @@ body {
   font-family: Geneva, Arial, Helvetica, sans-serif;    
   background-color: rgba(100, 100, 100, 0.3);
   font-size: 14px;
+  
+  /* CSS rule to disable text selection highlighting on editor window */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
 }
 
 body #center {


### PR DESCRIPTION
I added this css rule to `body` on `cats.css` file to disable text selection highlighting on editor window.

``` css
body {
    ...
    -webkit-touch-callout: none;
    -webkit-user-select: none;
}
```

![cats_text_selection_highlighting](https://f.cloud.github.com/assets/373936/248428/f2d04728-8b0d-11e2-8dbf-7dd35f2d2cbd.png)
