### PR TITLE
Avoid calling PATH.join on null or undefined.

### DIFF
--- a/src/cats/project.ts
+++ b/src/cats/project.ts
@@ -85,9 +85,9 @@ module Cats {
                 this.iSense.addScript(fullName, libdts);
             }
 
-            var srcPaths = [].concat(<any>this.config.srcPath);
+            var srcPaths = [].concat(<any>this.config.sourcePath);
             srcPaths.forEach((srcPath: string) => {
-                var fullPath = PATH.join(this.projectDir, srcPath);
+                var fullPath = PATH.join(this.projectDir, srcPath || '');
                 this.loadTypeScriptFiles(fullPath);
                 // this.initTSWorker(); @TODO still needed ?
             });


### PR DESCRIPTION
It fails to start on a new machine with the latest node-webkit. With this fix it works.

Maybe the behaviour of PATH module was changed recently?
