### PR TITLE
Init EditSession with project config.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3713,6 +3713,7 @@ var Cats;
                     }
                     _super.call(this, content, this.mode);
                     this.setNewLineMode("unix");
+                    this.configureAceSession(Cats.IDE.project.config);
                     this.setUndoManager(new UndoManager());
                     Cats.IDE.project.on("config", function (c) {
                         _this.configureAceSession(c);

--- a/src/cats/gui/editor/editSession.ts
+++ b/src/cats/gui/editor/editSession.ts
@@ -49,6 +49,7 @@ module Cats.Gui.Editor {
             
             super(content, this.mode);
             this.setNewLineMode("unix");
+            this.configureAceSession(IDE.project.config);
             this.setUndoManager(new UndoManager());
 
             IDE.project.on("config", (c) => { this.configureAceSession(c); });


### PR DESCRIPTION
Before this patch, tab/indent settings are not applied to newly opened file.
