### PR TITLE
Fix tooltip blink issue when UA fires zero-length mousemove events perio...

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3525,6 +3525,8 @@ var Cats;
                     var _this = this;
                     _super.call(this, "");
                     this.editor = editor;
+                    this.mouseX = 0;
+                    this.mouseY = 0;
                     this.exclude();
                     this.setRich(true);
                     this.setMaxWidth(500);
@@ -3558,7 +3560,14 @@ var Cats;
                 };
                 TSTooltip.prototype.onMouseMove = function (ev) {
                     var _this = this;
-                    if (this.isSeeable())
+                    var oldX = this.mouseX, oldY = this.mouseY;
+                    this.mouseX = ev.clientX;
+                    this.mouseY = ev.clientY;
+                    // Some UA may fire mousemove events periodically even if the mouse is not moving,
+                    // so we must not hide tooltip in this situation to avoid blink.
+                    if ((this.mouseX - oldX === 0) && (this.mouseY - oldY === 0))
+                        return;
+                    else if (this.isSeeable())
                         this.exclude();
                     if (!this.editor.isTypeScript())
                         return;


### PR DESCRIPTION
At least on my windows 7 laptop, node-webkit and chrome may fire zero-length mousemove events about once per second even if the mouse is not moving, which makes the tooltip blink. This patch fix the issue.
