### PR TITLE
Fixed issue with missing output file when compiling to a single output a...

### DIFF
--- a/lib/tsworker.js
+++ b/lib/tsworker.js
@@ -558,7 +558,7 @@ var Cats;
                             });
                         });
                         // No need to request other files if there is only one output file
-                        if (this.lsHost.getCompilationSettings().out) {
+                        if (result.length > 0 && this.lsHost.getCompilationSettings().out) {
                             break;
                         }
                     }

--- a/src/tsworker/isense.ts
+++ b/src/tsworker/isense.ts
@@ -279,7 +279,7 @@ module Cats.TSWorker {
                     });
 
                     // No need to request other files if there is only one output file
-                    if (this.lsHost.getCompilationSettings().out) {
+                    if (result.length > 0 && this.lsHost.getCompilationSettings().out) {
                         break;
                     }
                 } catch (err) {/*ignore */}


### PR DESCRIPTION
When compilling to a single outputfile no output was generated. This since the fetch result loop only went thru once and that first file is lib.d.ts which being a definition file does not generate any output. By also verifying that at least one output file has been produced before exiting the loop the solution now works and combines all input files into one output file.